### PR TITLE
Add ap-northeast-3 and eu-north-1 to default regions

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:local": "VITE_LOCAL=1 vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview"
   },

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -3,8 +3,7 @@ import { useState } from 'react';
 import Header from './components/Header';
 import Cards from './components/Cards';
 import TimezonePicker from './components/TimezonePicker';
-import { Virgo, Virgo2AWS } from '@mcteamster/virgo' // Production
-// import { Virgo, Virgo2AWS } from '../../src/index.ts' // Local Development
+import { Virgo, Virgo2AWS } from '@mcteamster/virgo'
 
 const styles = {
   body: {

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: process.env.VITE_LOCAL
+      ? { '@mcteamster/virgo': path.resolve(__dirname, '../src/index.ts') }
+      : {},
+  },
 })

--- a/dist/src/virgo2aws.js
+++ b/dist/src/virgo2aws.js
@@ -56,11 +56,13 @@ var Virgo2AWS = /** @class */ (function (_super) {
     Virgo2AWS.awsDefaultRegions = [
         "ap-northeast-1",
         "ap-northeast-2",
+        "ap-northeast-3",
         "ap-south-1",
         "ap-southeast-1",
         "ap-southeast-2",
         "ca-central-1",
         "eu-central-1",
+        "eu-north-1",
         "eu-west-1",
         "eu-west-2",
         "eu-west-3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcteamster/virgo",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A browser library for approximating user location (and distance) based on timezone",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/virgo2aws.ts
+++ b/src/virgo2aws.ts
@@ -7,11 +7,13 @@ export class Virgo2AWS extends Virgo {
   public static readonly awsDefaultRegions: string[] = [
     "ap-northeast-1",
     "ap-northeast-2",
+    "ap-northeast-3",
     "ap-south-1",
     "ap-southeast-1",
     "ap-southeast-2",
     "ca-central-1",
     "eu-central-1",
+    "eu-north-1",
     "eu-west-1",
     "eu-west-2",
     "eu-west-3",

--- a/test/virgo2aws.test.ts
+++ b/test/virgo2aws.test.ts
@@ -3,6 +3,12 @@ import { Virgo } from '../src/virgo';
 import { Virgo2AWS } from '../src/virgo2aws';
 
 describe('Virgo2AWS', () => {
+  it('should have 17 default AWS regions', () => {
+    expect(Virgo2AWS.awsDefaultRegions).toHaveLength(17);
+    expect(Virgo2AWS.awsDefaultRegions).toContain('ap-northeast-3');
+    expect(Virgo2AWS.awsDefaultRegions).toContain('eu-north-1');
+  });
+
   it('should return the closest AWS region', () => {
     const result = Virgo2AWS.getClosestRegion();
     console.log(result)
@@ -13,7 +19,7 @@ describe('Virgo2AWS', () => {
   it('should return the closest AWS region to Asia/Tokyo', () => {
     const result = Virgo2AWS.getClosestRegion({ origin: { latitude: 36.01, longitude: 136.51 } });
     console.log(result)
-    expect(result.closestRegion).toBe('ap-northeast-1');
+    expect(result.closestRegion).toBe('ap-northeast-3');
   });
 
   it('should return the closest AWS region to Europe/London out of the specified regions', () => {


### PR DESCRIPTION
AWS now has 17 default-enabled regions. Updates `awsDefaultRegions` to add:

- `ap-northeast-3` (Osaka)
- `eu-north-1` (Stockholm)

Also:
- Updated tests (new count assertion, corrected closest-region expectation for central Japan coordinates)
- Added `dev:local` script and Vite env alias for local development
- Bumped version to 0.2.5

Ref: https://docs.aws.amazon.com/general/latest/gr/rande-manage.html